### PR TITLE
Equalizer of cocycle with basepoint section

### DIFF
--- a/Final/Final-thms.agda
+++ b/Final/Final-thms.agda
@@ -8,6 +8,8 @@ module Final-thms where
 open import Sinh-classif public
 -- a description of the group action from the Sính triple of a given higher group
 open import Sinh-action public
+-- a description of the pullback of the associated cocycle along the basepoint section
+open import Sinh-fiber public
 
 {- type equivalence between coherent 2-groups and pointed connected 2-types as well as
    composite type equivalence between coherent 2-groups and Sính triples -}

--- a/Final/Final-thms.agda
+++ b/Final/Final-thms.agda
@@ -8,8 +8,8 @@ module Final-thms where
 open import Sinh-classif public
 -- a description of the group action from the Sính triple of a given higher group
 open import Sinh-action public
--- a description of the pullback of the associated cocycle along the basepoint section
-open import Sinh-fiber public
+-- a description of the equalizer of the associated cocycle with the basepoint section
+open import Sinh-cocycle public
 
 {- type equivalence between coherent 2-groups and pointed connected 2-types as well as
    composite type equivalence between coherent 2-groups and Sính triples -}

--- a/Final/README.md
+++ b/Final/README.md
@@ -9,7 +9,7 @@ finishes successfully on the following machine:
 
 *macOS Sequoia 15.6, Apple M1 chip, 16 GB of RAM*
 
-The type-checking takes about 4.3 hours in total (see [stats.md](stats.md)).
+The type-checking takes just under 4.5 hours in total (see [stats.md](stats.md)).
 Note that macOS, unlike Linux, dynamically alters the size of the swap
 space as the process runs. This is crucial because the type-checking uses
 as much as 28 GB of physical memory. Therefore, you will need to increase

--- a/Final/stats.md
+++ b/Final/stats.md
@@ -1,39 +1,38 @@
 **Total time taken on macOS Sequoia 15.6 (with M1 chip and 16 GB of RAM):**
 
 ```
-Total                            15,551,036ms               
-Miscellaneous                         2,093ms               
-Typing                              959,359ms (14,087,187ms)
-Typing.CheckRHS                   6,251,529ms               
-Typing.InstanceSearch             4,495,479ms               
-Typing.OccursCheck                1,696,559ms               
-Typing.TypeSig                      675,551ms               
-Typing.CheckLHS                       6,096ms      (8,685ms)
-Typing.CheckLHS.UnifyIndices          2,588ms               
+Total                            16,097,086ms               
+Miscellaneous                         2,299ms               
+Typing                            1,015,266ms (14,565,121ms)
+Typing.CheckRHS                   6,443,143ms               
+Typing.InstanceSearch             4,680,463ms               
+Typing.OccursCheck                1,735,640ms               
+Typing.TypeSig                      682,754ms               
+Typing.CheckLHS                       6,693ms      (7,829ms)
+Typing.CheckLHS.UnifyIndices          1,136ms               
 Typing.With                              23ms               
-Serialization                       380,522ms    (465,804ms)
-Serialization.BuildInterface         81,797ms               
-Serialization.Compress                1,645ms               
-Serialization.BinaryEncode            1,542ms               
-Serialization.Sort                      297ms               
-DeadCode                                354ms    (379,829ms)
-DeadCode.DeadCodeInstantiateFull    361,735ms               
-DeadCode.DeadCodeReachable           17,739ms               
-Positivity                          351,244ms               
-ProjectionLikeness                   83,488ms               
-Termination                             581ms     (57,922ms)
-Termination.RecCheck                 57,321ms               
-Termination.Graph                        11ms               
-Coverage                             50,183ms     (51,109ms)
-Coverage.UnifyIndices                   926ms               
-Parsing                               1,293ms     (37,554ms)
-Parsing.OperatorsExpr                34,909ms               
-Parsing.OperatorsPattern              1,352ms               
-Scoping                               1,945ms     (26,848ms)
-Scoping.InverseScopeLookup           24,902ms               
-Deserialization                       4,674ms      (6,365ms)
-Deserialization.Compaction            1,691ms               
-Highlighting                          1,229ms               
-Import                                  297ms               
-Injectivity                              69ms
+Serialization                       409,567ms    (496,751ms)
+Serialization.BuildInterface         83,904ms               
+Serialization.Compress                1,656ms               
+Serialization.BinaryEncode            1,317ms               
+Serialization.Sort                      305ms               
+Positivity                          391,706ms               
+DeadCode                                508ms    (376,434ms)
+DeadCode.DeadCodeInstantiateFull    355,145ms               
+DeadCode.DeadCodeReachable           20,779ms               
+ProjectionLikeness                   85,717ms               
+Coverage                             53,355ms     (54,291ms)
+Coverage.UnifyIndices                   935ms               
+Termination                             335ms     (52,281ms)
+Termination.RecCheck                 51,932ms               
+Parsing                               1,325ms     (37,741ms)
+Parsing.OperatorsExpr                35,051ms               
+Parsing.OperatorsPattern              1,363ms               
+Scoping                               1,949ms     (27,031ms)
+Scoping.InverseScopeLookup           25,082ms               
+Deserialization                       4,407ms      (6,113ms)
+Deserialization.Compaction            1,706ms               
+Highlighting                          1,212ms               
+Import                                  324ms               
+Injectivity                              73ms
 ```

--- a/HoTT-Agda/theorems/homotopy/EilenbergMacLane.agda
+++ b/HoTT-Agda/theorems/homotopy/EilenbergMacLane.agda
@@ -200,8 +200,8 @@ module EMExplicit {i} (G : AbGroup i) where
     ap (fst (⊙–> (deloop'-fold (S n)))) (Ω^'S-fmap-∙ n (⊙–> (spectrum (S n))) g₁ g₂) ∙ deloop'-fold-pres-comp n _ _
 
   instance
-    EM-SS-+2+ : {n : ℕ} → has-level (S (S (⟨ n ⟩₋₂ +2+ S (S ⟨ n ⟩₋₂)))) (EM (S (S n)))
-    EM-SS-+2+ {n} =
+    EM-SS-+2+-exp : {n : ℕ} → has-level (S (S (⟨ n ⟩₋₂ +2+ S (S ⟨ n ⟩₋₂)))) (EM (S (S n)))
+    EM-SS-+2+-exp {n} =
       transport! (λ l → has-level l (EM (S (S n)))) (+2+-βr (S (S (⟨ n ⟩₋₂))) (S ⟨ n ⟩₋₂) ∙ +2+-βr (S (S (S (⟨ n ⟩₋₂)))) ⟨ n ⟩₋₂) aux
       where abstract
         aux : ∀ {n} → has-level (S (S (S (S (⟨ n ⟩₋₂ +2+ ⟨ n ⟩₋₂))))) (EM (S (S n)))
@@ -224,7 +224,7 @@ module EMExplicit {i} (G : AbGroup i) where
 -- making instance argument available for instance search
 module _ {i} {G : AbGroup i} where
 
-  open EMExplicit G renaming (EM-SS-+2+ to EM-SS-+2+-exp)
+  open EMExplicit G
   
   instance
     EM-SS-+2+ : {n : ℕ} → has-level (S (S (⟨ n ⟩₋₂ +2+ S (S ⟨ n ⟩₋₂)))) (EM (S (S n)))

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ collecting the main theorems.
 - `Final/`
 
   A single file containing the final biadjoint biequivalence and equality, 
-  Milner's equivalence along with a description of the group action produced by the equivalence,
+  Milner's equivalence along with descriptions of the group action and cocycle produced by the equivalence,
   and the composite type equivalence between pointed connected 2-types and Sính triples.
 
   See `Final/README.md` for details and for the license of the work inside this directory.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ collecting the main theorems.
 
 - `HoTT-Agda/`
 
-  A stripped down version of Andrew Swan's [HoTT-Agda](https://github.com/awswan/HoTT-Agda/tree/agda-2.6.1-compatible) branch,
+  A stripped-down version of Andrew Swan's [HoTT-Agda](https://github.com/awswan/HoTT-Agda/tree/agda-2.6.1-compatible) branch,
   with many changes and additions motivated by our construction
   of the biadjoint biequivalence and by Milner's equivalence.
 
@@ -72,7 +72,7 @@ We have successfully tested the following Docker container on Linux with 16 GB o
    docker run --mount type=bind,source=./html,target=/Final/html 2group
    ```
 
-   This may take a few minutes. The HTML files will be under `html/`, and
+   This will take several minutes. The HTML files will be under `html/`, and
    `html/Final-thms.agda.html` will be the entry point.
 
 If you can avoid the overhead of Docker, we suggest that you do so even if you
@@ -81,8 +81,8 @@ have lots of available RAM.
 We have found that type-checking directly on a macOS with an M1 chip is much
 faster (but still intensive). See `Final/README.md` for relevant details.
 
-**Important:** Comment out the final two imports in `Final/Final-thms` to reduce the type-checking by over an hour. Doing so will check
-all relevant type equivalences but not the biadjoint biequivalence.
+**Important:** Comment out the final four imports in `Final/Final-thms.agda` to reduce the type-checking by over half.
+Doing so will check all relevant type equivalences but not the biadjoint biequivalence.
 
 ## Acknowledgement
 

--- a/Sinh/README.md
+++ b/Sinh/README.md
@@ -9,7 +9,8 @@ We also obtain a set-truncated version of the equivalence, between components of
 consisting of an *n*-group BG, a G-module H : BG -> Ab, and a cohomology class in H^(*n*+2)(G, H).
 
 This directory also contains a proof that the action of the Sính triple for a given *n*-group BG (where *n* ≥ 2) is 
-the canonical action of the fundamental n-group Πₙ(BG) on the abelian group πₙ(BG).
+the canonical action of the fundamental n-group Πₙ(BG) on the abelian group πₙ(BG). Finally, it contains a proof that 
+the pullback of the associated cocycle along the basepoint section of the Eilenberg-MacLane type family is BG itself.
 
 ## License
 

--- a/Sinh/README.md
+++ b/Sinh/README.md
@@ -10,7 +10,7 @@ consisting of an *n*-group BG, a G-module H : BG -> Ab, and a cohomology class i
 
 This directory also contains a proof that the action of the Sính triple for a given *n*-group BG (where *n* ≥ 2) is 
 the canonical action of the fundamental n-group Πₙ(BG) on the abelian group πₙ(BG). Finally, it contains a proof that 
-the pullback of the associated cocycle along the basepoint section of the Eilenberg-MacLane type family is BG itself.
+the equalizer of the associated cocycle with the basepoint section of the Eilenberg-MacLane type family is BG itself.
 
 ## License
 

--- a/Sinh/Sinh-action.agda
+++ b/Sinh/Sinh-action.agda
@@ -11,9 +11,6 @@ module Sinh-action where
 
 module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
 
-  NGrp-Sinh–> : [ S (S n) , i ]-Groups → Sinh-triples (S n) i
-  NGrp-Sinh–> = –> NGrp-Sinh-≃
-
   NGrp-Sinh-≃-group : fst (fst (NGrp-Sinh–> G)) == ⊙Trunc ⟨ S n ⟩ X
   NGrp-Sinh-≃-group = idp
 

--- a/Sinh/Sinh-classif.agda
+++ b/Sinh/Sinh-classif.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting #-}
 
 open import HoTT
 open import lib.types.N-groups
@@ -32,8 +32,14 @@ module _ (n : ℕ) (i : ULevel) where
 module _ {n : ℕ} {i : ULevel} where
 
   -- [ S (S n) , i ]-Groups is defined in lib.types.N-groups
-  NGrp-Sinh-≃ : [ S (S n) , i ]-Groups ≃ Sinh-triples (S n) i
-  NGrp-Sinh-≃ =
+  NGrp-Sinh-≃-pre :
+    [ S (S n) , i ]-Groups
+      ≃
+    [ (X , cX , tX) ∈ [ S n , i ]-Groups ] ×
+      [ H ∈ (de⊙ X → AbGroup i) ] ×
+        Π⊙ X (λ u → Torsors i (⊙EM (H u) (S (S n))))
+          (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}} {{EM-SS-+2+ {G = H (pt X)}}}}}))
+  NGrp-Sinh-≃-pre =
     [ S (S n) , i ]-Groups
       ≃⟨ N-Grps-≃ ⟩
     [ (S n) , i , i ]-Groups-v2
@@ -96,21 +102,8 @@ module _ {n : ℕ} {i : ULevel} where
     [ (X , cX , tX) ∈ [ S n , i ]-Groups ] ×
       [ H ∈ (de⊙ X → AbGroup i) ] ×
           Π⊙ X (λ u → Torsors i (⊙EM (H u) (S (S n))))
-            (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}}}}))
-      ≃⟨ Σ-emap-r (λ (X , cX , tX) →
-           Σ-emap-r (λ H → Π⊙-==-ext ((λ u → (EM-Torsors-≃ (H u)) ⁻¹) , ptdness X H))) ⟩
-    [ (X , cX , tX) ∈ [ S n , i ]-Groups ] ×
-      [ H ∈ (de⊙ X → AbGroup i) ] ×
-        Π⊙ X (λ u → EM (H u) (S (S (S n)))) (ptEM (H (pt X)) (S (S (S n)))) ≃∎
+            (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}}}})) ≃∎
       module Sinh-classif-lemmas where
-
-        -- proof of pointedness in final equivalence
-        ptdness : (X : Ptd i) (H : de⊙ X → AbGroup i) →
-          fst (⊙–> (⊙EM-Torsors-≃ (H (pt X)) ⊙⁻¹))
-            (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}}}}))
-            ==
-          pt (⊙EM (H (pt X)) (S (S (S n))))
-        ptdness X H = ⊙–>-pt (⊙EM-Torsors-≃ (H (pt X)) {n} ⊙⁻¹)
 
         -- the second equivalence: adding singletons 
         orthog-contr :
@@ -185,6 +178,32 @@ module _ {n : ℕ} {i : ULevel} where
                   (ap (λ q → ap (λ tr → Ω^'S-abgroup n ⊙[ F u , x ] {{tr}}) q ∙' snd (snd (m u)) x)
                     (prop-has-all-paths {{=-preserves-level ⟨⟩}} _ _))))))))
               idp
+
+  -- we separate the last equivalence as elsewhere we want direct access to the preceding chain
+  NGrp-Sinh-≃ : [ S (S n) , i ]-Groups ≃ Sinh-triples (S n) i
+  NGrp-Sinh-≃ =
+    [ S (S n) , i ]-Groups
+      ≃⟨ NGrp-Sinh-≃-pre ⟩
+    [ (X , cX , tX) ∈ [ S n , i ]-Groups ] ×
+      [ H ∈ (de⊙ X → AbGroup i) ] ×
+          Π⊙ X (λ u → Torsors i (⊙EM (H u) (S (S n))))
+            (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}}}}))
+      ≃⟨ Σ-emap-r (λ (X , cX , tX) →
+           Σ-emap-r (λ H → Π⊙-==-ext ((λ u → (EM-Torsors-≃ (H u)) ⁻¹) , ptdness X H))) ⟩
+    [ (X , cX , tX) ∈ [ S n , i ]-Groups ] ×
+      [ H ∈ (de⊙ X → AbGroup i) ] ×
+        Π⊙ X (λ u → EM (H u) (S (S (S n)))) (ptEM (H (pt X)) (S (S (S n)))) ≃∎
+      module Sinh-classif-final where
+        ptdness : (X : Ptd i) (H : de⊙ X → AbGroup i) →
+          fst (⊙–> (⊙EM-Torsors-≃ (H (pt X)) ⊙⁻¹))
+            (pt (⊙Torsors (⊙EM (H (pt X)) (S (S n))) {{PtdTorsors-contr {{EM-conn (H (pt X))}}}}))
+            ==
+          pt (⊙EM (H (pt X)) (S (S (S n))))
+        ptdness X H = ⊙–>-pt (⊙EM-Torsors-≃ (H (pt X)) {n} ⊙⁻¹)
+
+
+  NGrp-Sinh–> : [ S (S n) , i ]-Groups → Sinh-triples (S n) i
+  NGrp-Sinh–> = –> NGrp-Sinh-≃
 
   {- a set-truncated version recovering the classical description
      of the Postnikov invariant as a cohomology class -}

--- a/Sinh/Sinh-cocycle.agda
+++ b/Sinh/Sinh-cocycle.agda
@@ -7,13 +7,13 @@ open import homotopy.EilenbergMacLane
 open import torsors.Delooping
 open import Sinh-classif
 
-{- Consider the cocyle produced by the Sính triple for a given n-group BG.
-   Its pullback along the basepoint section of the Eilenberg-MacLane type
-   family is BG itself. -}
+{- Consider the cocycle produced by the Sính triple for a given n-group BG.
+   The equalizer of the cocycle with the basepoint section of the Eilenberg-MacLane
+   type family is BG itself. -}
 
-module Sinh-fiber where
+module Sinh-cocycle where
 
-module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
+module _ {n : ℕ} {i : ULevel} (G@(X , _ , _) : [ S (S n) , i ]-Groups) where
 
   open EMExplicit
 
@@ -36,18 +36,22 @@ module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
     NGrp-Sinh-coc-tors-fib = idp
 
     abstract
-      NGrp-Sinh-coc-tors-fib-≃ :
+      NGrp-Sinh-coc-tors-fib-pt :
         (hfiber [_] x)
           ≃
         (fst cocycle-tors x == pt (⊙Torsors (⊙EM (action x) (S (S n))) {{PtdTorsors-contr {{EM-conn (action x)}}}}))
-      NGrp-Sinh-coc-tors-fib-≃ =
+      NGrp-Sinh-coc-tors-fib-pt =
         tors-ptd-is-trivial (⊙EM (fst (snd (–> NGrp-Sinh-≃-pre G)) x) (S (S n))) {{PtdTorsors-contr {{EM-conn (action x)}}}}
 
-    NGrp-Sinh-coc-fib-≃ :
+    NGrp-Sinh-coc-fib-pt :
       (hfiber [_] x)
         ≃
       (fst cocycle x == pt (⊙EM (action x) (S (S (S n)))))
-    NGrp-Sinh-coc-fib-≃ =
+    NGrp-Sinh-coc-fib-pt =
       post∙-equiv (⊙–>-pt ((⊙EM-Torsors-≃ (action x)) ⊙⁻¹)) ∘e
       ap-equiv ((EM-Torsors-≃ (action x)) ⁻¹) _ _ ∘e
-      NGrp-Sinh-coc-tors-fib-≃
+      NGrp-Sinh-coc-tors-fib-pt
+
+  -- taking total spaces
+  NGrp-Sinh-coc-fib-≃ : Σ (de⊙ (⊙Trunc ⟨ S n ⟩ X)) (λ x → fst cocycle x == pt (⊙EM (action x) (S (S (S n))))) ≃ de⊙ X
+  NGrp-Sinh-coc-fib-≃ = total-hfib-≃ [_] ∘e (Σ-emap-r NGrp-Sinh-coc-fib-pt) ⁻¹

--- a/Sinh/Sinh-fiber.agda
+++ b/Sinh/Sinh-fiber.agda
@@ -7,7 +7,7 @@ open import homotopy.EilenbergMacLane
 open import torsors.Delooping
 open import Sinh-classif
 
-{- Consider the cocyle produced by the Sinh-triple for a given n-group BG.
+{- Consider the cocyle produced by the Sính triple for a given n-group BG.
    Its pullback along the basepoint section of the Eilenberg-MacLane type
    family is BG itself. -}
 
@@ -18,11 +18,15 @@ module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
   open EMExplicit
 
   private
-  
+
+    -- action from the Sính triple
     action : de⊙ (⊙Trunc ⟨ S n ⟩ X) → AbGroup i
     action = fst (snd (NGrp-Sinh–> G))
 
+    -- cocycle from the Sính triple
     cocycle = snd (snd (NGrp-Sinh–> G))
+    
+    -- torsor variant of the cocycle
     cocycle-tors = snd (snd (–> NGrp-Sinh-≃-pre G))
 
   module _ (x : de⊙ (⊙Trunc ⟨ S n ⟩ X)) where
@@ -43,4 +47,7 @@ module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
       (hfiber [_] x)
         ≃
       (fst cocycle x == pt (⊙EM (action x) (S (S (S n)))))
-    NGrp-Sinh-coc-fib-≃ = {!!} ∘e NGrp-Sinh-coc-tors-fib-≃
+    NGrp-Sinh-coc-fib-≃ =
+      post∙-equiv (⊙–>-pt ((⊙EM-Torsors-≃ (action x)) ⊙⁻¹)) ∘e
+      ap-equiv ((EM-Torsors-≃ (action x)) ⁻¹) _ _ ∘e
+      NGrp-Sinh-coc-tors-fib-≃

--- a/Sinh/Sinh-fiber.agda
+++ b/Sinh/Sinh-fiber.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --without-K --rewriting --lossy-unification #-}
+
+open import HoTT
+open import lib.types.N-groups
+open import lib.types.Torsor
+open import homotopy.EilenbergMacLane
+open import torsors.Delooping
+open import Sinh-classif
+
+{- Consider the cocyle produced by the Sinh-triple for a given n-group BG.
+   Its pullback along the basepoint section of the Eilenberg-MacLane type
+   family is BG itself. -}
+
+module Sinh-fiber where
+
+module _ {n : ℕ} {i : ULevel} (G@(X , cX , tX) : [ S (S n) , i ]-Groups) where
+
+  open EMExplicit
+
+  private
+  
+    action : de⊙ (⊙Trunc ⟨ S n ⟩ X) → AbGroup i
+    action = fst (snd (NGrp-Sinh–> G))
+
+    cocycle = snd (snd (NGrp-Sinh–> G))
+    cocycle-tors = snd (snd (–> NGrp-Sinh-≃-pre G))
+
+  module _ (x : de⊙ (⊙Trunc ⟨ S n ⟩ X)) where
+  
+    -- the underlying type of the associated torsor is definitionally the fiber of the truncation map
+    NGrp-Sinh-coc-tors-fib : fst (fst cocycle-tors x) == hfiber [_] x
+    NGrp-Sinh-coc-tors-fib = idp
+
+    abstract
+      NGrp-Sinh-coc-tors-fib-≃ :
+        (hfiber [_] x)
+          ≃
+        (fst cocycle-tors x == pt (⊙Torsors (⊙EM (action x) (S (S n))) {{PtdTorsors-contr {{EM-conn (action x)}}}}))
+      NGrp-Sinh-coc-tors-fib-≃ =
+        tors-ptd-is-trivial (⊙EM (fst (snd (–> NGrp-Sinh-≃-pre G)) x) (S (S n))) {{PtdTorsors-contr {{EM-conn (action x)}}}}
+
+    NGrp-Sinh-coc-fib-≃ :
+      (hfiber [_] x)
+        ≃
+      (fst cocycle x == pt (⊙EM (action x) (S (S (S n)))))
+    NGrp-Sinh-coc-fib-≃ = {!!} ∘e NGrp-Sinh-coc-tors-fib-≃


### PR DESCRIPTION
Adds a short proof that, for a given higher group $G$, the equalizer of the "Sính cocycle" with the basepoint section is the relevant truncation map of $G$.